### PR TITLE
change url to raw github one

### DIFF
--- a/projects/nvidia-jetbot-collision-avoidance/worlds/jetbot_collision_avoidance.wbt
+++ b/projects/nvidia-jetbot-collision-avoidance/worlds/jetbot_collision_avoidance.wbt
@@ -43,7 +43,7 @@ Floor {
   appearance PBRAppearance {
     baseColorMap ImageTexture {
       url [
-        "textures/square_block_parquetry.jpg"
+        "https://raw.githubusercontent.com/cyberbotics/webots/R2021a/projects/default/worlds/textures/square_block_parquetry.jpg"
       ]
     }
     roughness 1


### PR DESCRIPTION
Use a https URL for texture image in Webots R2021b.
Relates to cyberbotics/webots#2787